### PR TITLE
Correct AndroidManifest and res paths

### DIFF
--- a/robolectric-tests/src/test/java/com/example/RobolectricGradleSubModuleTestRunner.java
+++ b/robolectric-tests/src/test/java/com/example/RobolectricGradleSubModuleTestRunner.java
@@ -19,11 +19,11 @@ public class RobolectricGradleSubModuleTestRunner extends RobolectricTestRunner 
     }
 
     protected String getAndroidManifestPath() {
-        return "../deckard-gradle/app/src/main/AndroidManifest.xml";
+        return "../app/src/main/AndroidManifest.xml";
     }
 
     protected String getResPath() {
-        return "../deckard-gradle/app/src/main/res";
+        return "../app/src/main/res";
     }
 
     @Override


### PR DESCRIPTION
This commit corrects the relative paths to AndroidManifest.xml and the
res directory in RobolectricGradleSubModuleTestRunner.class
